### PR TITLE
✨Usability Update(1.3.0)✨

### DIFF
--- a/assimilator/alchemy/__init__.py
+++ b/assimilator/alchemy/__init__.py
@@ -1,7 +1,7 @@
 import sqlalchemy
 
 from assimilator.core.services import CRUDService
-from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.core.usability.registry import register_provider, PatternList
 from assimilator.alchemy.database import AlchemyRepository, AlchemyUnitOfWork
 
 
@@ -12,7 +12,7 @@ if sqlalchemy.__version__ < "2.0.0":
     )
 
 
-register_pattern(provider='alchemy', pattern_list=PatternList(
+register_provider(provider='alchemy', pattern_list=PatternList(
     repository=AlchemyRepository,
     uow=AlchemyUnitOfWork,
     crud=CRUDService

--- a/assimilator/alchemy/__init__.py
+++ b/assimilator/alchemy/__init__.py
@@ -1,7 +1,19 @@
 import sqlalchemy
 
+from assimilator.core.services import CRUDService
+from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.alchemy.database import AlchemyRepository, AlchemyUnitOfWork
+
+
 if sqlalchemy.__version__ < "2.0.0":
     raise RuntimeWarning(
         "PyAssimilator will only support SQLAlchemy 2 from now on. Please, update "
         "the library using this manual: https://docs.sqlalchemy.org/en/20/changelog/migration_20.html"
     )
+
+
+register_pattern(provider='alchemy', pattern_list=PatternList(
+    repository=AlchemyRepository,
+    uow=AlchemyUnitOfWork,
+    crud=CRUDService
+))

--- a/assimilator/core/usability/exceptions.py
+++ b/assimilator/core/usability/exceptions.py
@@ -1,0 +1,8 @@
+
+
+class PatternNotFoundError(KeyError):
+    pass
+
+
+class ProviderNotFoundError(KeyError):
+    pass

--- a/assimilator/core/usability/pattern_creator.py
+++ b/assimilator/core/usability/pattern_creator.py
@@ -1,0 +1,53 @@
+from typing import TypeVar, Any, Callable
+
+from assimilator.core.usability.registry import create_pattern
+from assimilator.core.database import Repository, UnitOfWork
+from assimilator.core.services import CRUDService
+
+ModelT = TypeVar("ModelT")
+
+
+def create_repository(
+    provider: str,
+    model: ModelT,
+    session: Any,
+    **kwargs,
+) -> Repository:
+    return create_pattern(
+        provider=provider,
+        pattern_name='repository',
+        model=model,
+        session=session,
+        **kwargs,
+    )
+
+
+def create_uow(
+    provider: str,
+    model: ModelT,
+    session: Any,
+    repository_creator: Callable = create_repository,   # TODO: fix annotation
+    **kwargs,
+) -> UnitOfWork:
+    repository = repository_creator(provider=provider, model=model, session=session)
+    return create_pattern(
+        provider=provider,
+        pattern_name='uow',
+        repository=repository,
+        **kwargs,
+    )
+
+
+def create_crud_service(
+    provider: str,
+    model: ModelT,
+    session: Any,
+    **kwargs,
+) -> CRUDService:
+    uow = create_uow(provider=provider, model=model, session=session)
+    return create_pattern(
+        provider=provider,
+        pattern_name='crud',
+        uow=uow,
+        **kwargs,
+    )

--- a/assimilator/core/usability/registry.py
+++ b/assimilator/core/usability/registry.py
@@ -20,11 +20,11 @@ class PatternList(BaseModel):
 registry: Dict[str, PatternList] = {}
 
 
-def register_pattern(provider: str, pattern_list: PatternList):
+def register_provider(provider: str, pattern_list: PatternList):
     registry[provider] = pattern_list
 
 
-def find_patterns(provider_path: str):
+def find_provider(provider_path: str):
     """ Imports a module that has automatic pattern registration """
     importlib.import_module(provider_path)
 
@@ -33,8 +33,11 @@ def get_pattern_list(provider: str):
     return registry[provider]
 
 
-def unregister_pattern(name: str):
-    del registry[name]
+def unregister_provider(provider: str):
+    try:
+        del registry[provider]
+    except KeyError:
+        raise ProviderNotFoundError(f"Provider {provider} was not found")
 
 
 def get_pattern(provider: str, pattern_name: str) -> Type[Union[Repository, UnitOfWork, CRUDService]]:
@@ -50,10 +53,10 @@ def get_pattern(provider: str, pattern_name: str) -> Type[Union[Repository, Unit
 
 
 __all__ = [
-    'register_pattern',
-    'unregister_pattern',
+    'register_provider',
+    'unregister_provider',
     'PatternList',
     'get_pattern_list',
     'get_pattern',
-    'find_patterns',
+    'find_provider',
 ]

--- a/assimilator/core/usability/registry.py
+++ b/assimilator/core/usability/registry.py
@@ -1,0 +1,48 @@
+from typing import Dict, Any, Literal, Type
+
+from pydantic import BaseModel
+
+from assimilator.core.database import Repository, UnitOfWork
+from assimilator.core.services.crud import CRUDService
+
+
+class PatternList(BaseModel):
+    class Config:
+        frozen = True
+
+    repository: Type[Repository]
+    uow: Type[UnitOfWork]
+    crud: Type[CRUDService]
+
+
+registry: Dict[str, PatternList] = {}
+
+
+def register_pattern(provider: str, pattern_list: PatternList):
+    registry[provider] = pattern_list
+
+
+def get_pattern_list(provider: str):
+    return registry[provider]
+
+
+def unregister_pattern(name: str):
+    del registry[name]
+
+
+def create_pattern(
+    provider: str,
+    pattern_name: Literal['uow', 'repository', 'crud'],
+    *init_args,
+    **init_kwargs,
+) -> Any:
+    return getattr(registry[provider], pattern_name)(*init_args, **init_kwargs)
+
+
+__all__ = [
+    'create_pattern',
+    'register_pattern',
+    'unregister_pattern',
+    'PatternList',
+    'get_pattern_list',
+]

--- a/assimilator/internal/__init__.py
+++ b/assimilator/internal/__init__.py
@@ -1,8 +1,8 @@
 from assimilator.core.services import CRUDService
-from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.core.usability.registry import register_provider, PatternList
 from assimilator.internal.database import InternalRepository, InternalUnitOfWork
 
-register_pattern(provider='internal', pattern_list=PatternList(
+register_provider(provider='internal', pattern_list=PatternList(
     repository=InternalRepository,
     uow=InternalUnitOfWork,
     crud=CRUDService,

--- a/assimilator/internal/__init__.py
+++ b/assimilator/internal/__init__.py
@@ -1,0 +1,9 @@
+from assimilator.core.services import CRUDService
+from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.internal.database import InternalRepository, InternalUnitOfWork
+
+register_pattern(provider='internal', pattern_list=PatternList(
+    repository=InternalRepository,
+    uow=InternalUnitOfWork,
+    crud=CRUDService,
+))

--- a/assimilator/mongo/__init__.py
+++ b/assimilator/mongo/__init__.py
@@ -1,8 +1,8 @@
 from assimilator.core.services import CRUDService
-from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.core.usability.registry import register_provider, PatternList
 from assimilator.mongo.database import MongoRepository, MongoUnitOfWork
 
-register_pattern(provider='mongo', pattern_list=PatternList(
+register_provider(provider='mongo', pattern_list=PatternList(
     repository=MongoRepository,
     uow=MongoUnitOfWork,
     crud=CRUDService,

--- a/assimilator/mongo/__init__.py
+++ b/assimilator/mongo/__init__.py
@@ -1,0 +1,9 @@
+from assimilator.core.services import CRUDService
+from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.mongo.database import MongoRepository, MongoUnitOfWork
+
+register_pattern(provider='mongo', pattern_list=PatternList(
+    repository=MongoRepository,
+    uow=MongoUnitOfWork,
+    crud=CRUDService,
+))

--- a/assimilator/redis_/__init__.py
+++ b/assimilator/redis_/__init__.py
@@ -1,0 +1,12 @@
+from assimilator.core.services import CRUDService
+from assimilator.redis_.database import RedisRepository, RedisUnitOfWork
+from assimilator.core.usability.registry import register_pattern, PatternList
+
+pattern_list = PatternList(
+    repository=RedisRepository,
+    uow=RedisUnitOfWork,
+    crud=CRUDService,
+)
+
+register_pattern(provider='redis', pattern_list=pattern_list)
+register_pattern(provider='redis_', pattern_list=pattern_list)

--- a/assimilator/redis_/__init__.py
+++ b/assimilator/redis_/__init__.py
@@ -1,6 +1,6 @@
 from assimilator.core.services import CRUDService
 from assimilator.redis_.database import RedisRepository, RedisUnitOfWork
-from assimilator.core.usability.registry import register_pattern, PatternList
+from assimilator.core.usability.registry import register_provider, PatternList
 
 pattern_list = PatternList(
     repository=RedisRepository,
@@ -8,5 +8,5 @@ pattern_list = PatternList(
     crud=CRUDService,
 )
 
-register_pattern(provider='redis', pattern_list=pattern_list)
-register_pattern(provider='redis_', pattern_list=pattern_list)
+register_provider(provider='redis', pattern_list=pattern_list)
+register_provider(provider='redis_', pattern_list=pattern_list)

--- a/docs/docs_theme/base.html
+++ b/docs/docs_theme/base.html
@@ -1,0 +1,303 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% import "partials/language.html" as lang with context %}
+<!doctype html>
+<html lang="{{ lang.t('language') }}" class="no-js">
+  <head>
+    {% block site_meta %}
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      {% if page.meta and page.meta.description %}
+        <meta name="description" content="{{ page.meta.description }}">
+      {% elif config.site_description %}
+        <meta name="description" content="{{ config.site_description }}">
+      {% endif %}
+      {% if page.meta and page.meta.author %}
+        <meta name="author" content="{{ page.meta.author }}">
+      {% elif config.site_author %}
+        <meta name="author" content="{{ config.site_author }}">
+      {% endif %}
+      {% if page.canonical_url %}
+        <link rel="canonical" href="{{ page.canonical_url }}">
+      {% endif %}
+      <link rel="icon" href="{{ config.theme.favicon | url }}">
+      <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-material-8.5.10">
+    {% endblock %}
+    {% block htmltitle %}
+      {% if page.meta and page.meta.title %}
+        <title>{{ page.meta.title }} - {{ config.site_name }}</title>
+      {% elif page.title and not page.is_homepage %}
+        <title>{{ page.title | striptags }} - {{ config.site_name }}</title>
+      {% else %}
+        <title>{{ config.site_name }}</title>
+      {% endif %}
+    {% endblock %}
+    {% block styles %}
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/main.975780f9.min.css' | url }}">
+      {% if config.theme.palette %}
+        {% set palette = config.theme.palette %}
+        <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.2505c338.min.css' | url }}">
+        {% if palette.primary %}
+          {% import "partials/palette.html" as map %}
+          {% set primary = map.primary(
+            palette.primary | replace(" ", "-") | lower
+          ) %}
+          <meta name="theme-color" content="{{ primary }}">
+        {% endif %}
+      {% endif %}
+      {% include "partials/icons.html" %}
+    {% endblock %}
+    {% block libs %}{% endblock %}
+    {% block fonts %}
+      {% if config.theme.font != false %}
+        {% set text = config.theme.font.text | d("Roboto", true) %}
+        {% set code = config.theme.font.code | d("Roboto Mono", true) %}
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{
+            text | replace(' ', '+') + ':300,300i,400,400i,700,700i%7C' +
+            code | replace(' ', '+') + ':400,400i,700,700i'
+          }}&display=fallback">
+        <style>:root{--md-text-font:"{{ text }}";--md-code-font:"{{ code }}"}</style>
+      {% endif %}
+    {% endblock %}
+    {% for path in config.extra_css %}
+      <link rel="stylesheet" href="{{ path | url }}">
+    {% endfor %}
+    {% include "partials/javascripts/base.html" %}
+    {% block analytics %}
+      {% include "partials/integrations/analytics.html" %}
+    {% endblock %}
+    {% if page.meta and page.meta.meta %}
+      {% for tag in page.meta.meta %}
+        <meta {% for key, value in tag.items() %} {{ key }}="{{value}}" {% endfor %}>
+      {% endfor %}
+    {% endif %}
+    {% block extrahead %}{% endblock %}
+  </head>
+  {% set direction = config.theme.direction or lang.t('direction') %}
+  {% if config.theme.palette %}
+    {% set palette = config.theme.palette %}
+    {% if not palette is mapping %}
+      {% set palette = palette | first %}
+    {% endif %}
+    {% set scheme  = palette.scheme | d("default", true) %}
+    {% set primary = palette.primary %}
+    {% set accent  = palette.accent %}
+    <body dir="{{ direction }}" data-md-color-scheme="{{ scheme | replace(' ', '-') }}" data-md-color-primary="{{ primary | replace(' ', '-') }}" data-md-color-accent="{{ accent | replace(' ', '-') }}">
+  {% else %}
+    <body dir="{{ direction }}">
+  {% endif %}
+    {% set features = config.theme.features or [] %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
+    <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    <label class="md-overlay" for="__drawer"></label>
+    <div data-md-component="skip">
+      {% if page.toc | first is defined %}
+        {% set skip = page.toc | first %}
+        <a href="{{ skip.url | url }}" class="md-skip">
+          {{ lang.t('skip.link.title') }}
+        </a>
+      {% endif %}
+    </div>
+    <div data-md-component="announce">
+      {% if self.announce() %}
+        <aside class="md-banner">
+          <div class="md-banner__inner md-grid md-typeset">
+            {% if "announce.dismiss" in features %}
+              <button class="md-banner__button md-icon" aria-label="{{ lang.t('announce.dismiss') }}">
+                {% include ".icons/material/close.svg" %}
+              </button>
+            {% endif %}
+            {% block announce %}{% endblock %}
+          </div>
+          {% if "announce.dismiss" in features %}
+            {% include "partials/javascripts/announce.html" %}
+          {% endif %}
+        </aside>
+      {% endif %}
+    </div>
+    {% if config.extra.version %}
+      <div data-md-component="outdated" hidden>
+        {% if self.outdated() %}
+          <aside class="md-banner md-banner--warning">
+            <div class="md-banner__inner md-grid md-typeset">
+              {% block outdated %}{% endblock %}
+            </div>
+            {% include "partials/javascripts/outdated.html" %}
+          </aside>
+        {% endif %}
+      </div>
+    {% endif %}
+    {% block header %}
+      {% include "partials/header.html" %}
+    {% endblock %}
+    <div class="md-container" data-md-component="container">
+      {% block hero %}{% endblock %}
+      {% block tabs %}
+        {% if not "navigation.tabs.sticky" in features %}
+          {% if "navigation.tabs" in features %}
+            {% include "partials/tabs.html" %}
+          {% endif %}
+        {% endif %}
+      {% endblock %}
+      <main class="md-main" data-md-component="main">
+        <div class="md-main__inner md-grid">
+          {% block site_nav %}
+            {% if nav %}
+              {% if page.meta and page.meta.hide %}
+                {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+              {% endif %}
+              <div class="md-sidebar md-sidebar--primary" data-md-component="sidebar" data-md-type="navigation" {{ hidden }}>
+                <div class="md-sidebar__scrollwrap">
+                  <div class="md-sidebar__inner">
+                    {% include "partials/nav.html" %}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+            {% if not "toc.integrate" in features %}
+              {% if page.meta and page.meta.hide %}
+                {% set hidden = "hidden" if "toc" in page.meta.hide %}
+              {% endif %}
+              <div class="md-sidebar md-sidebar--secondary" data-md-component="sidebar" data-md-type="toc" {{ hidden }}>
+                <div class="md-sidebar__scrollwrap">
+                  <div class="md-sidebar__inner">
+                    {% include "partials/toc.html" %}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          {% endblock %}
+          {% block container %}
+            <div class="md-content" data-md-component="content">
+              <article class="md-content__inner md-typeset">
+                {% block content %}
+                  {% include "partials/content.html" %}
+                {% endblock %}
+              </article>
+            </div>
+          {% endblock %}
+          {% include "partials/javascripts/content.html" %}
+        </div>
+        {% if "navigation.top" in features %}
+          <a href="#" class="md-top md-icon" data-md-component="top" hidden>
+            {% include ".icons/material/arrow-up.svg" %}
+            {{ lang.t('top.title') }}
+          </a>
+        {% endif %}
+      </main>
+      {% block footer %}
+        {% include "partials/footer.html" %}
+      {% endblock %}
+    </div>
+    <div class="md-dialog" data-md-component="dialog">
+      <div class="md-dialog__inner md-typeset"></div>
+    </div>
+    {% if config.extra.consent %}
+      <div class="md-consent" data-md-component="consent" id="__consent" hidden>
+        <div class="md-consent__overlay"></div>
+        <aside class="md-consent__inner">
+          <form class="md-consent__form md-grid md-typeset" name="consent">
+            {% include "partials/consent.html" %}
+          </form>
+        </aside>
+      </div>
+      {% include "partials/javascripts/consent.html" %}
+    {% endif %}
+    {% block config %}
+      {%- set app = {
+        "base": base_url,
+        "features": features,
+        "translations": {},
+        "search": "assets/javascripts/workers/search.16e2a7d4.min.js" | url
+      } -%}
+      {%- if config.extra.version -%}
+        {%- set _ = app.update({ "version": config.extra.version }) -%}
+      {%- endif -%}
+      {%- if config.extra.tags -%}
+        {%- set _ = app.update({ "tags": config.extra.tags }) -%}
+      {%- endif -%}
+      {%- set translations = app.translations -%}
+      {%- for key in [
+        "clipboard.copy",
+        "clipboard.copied",
+        "search.config.lang",
+        "search.config.pipeline",
+        "search.config.separator",
+        "search.placeholder",
+        "search.result.placeholder",
+        "search.result.none",
+        "search.result.one",
+        "search.result.other",
+        "search.result.more.one",
+        "search.result.more.other",
+        "search.result.term.missing",
+        "select.version.title"
+      ] -%}
+        {%- set _ = translations.update({ key: lang.t(key) }) -%}
+      {%- endfor -%}
+      <script id="__config" type="application/json">
+        {{- app | tojson -}}
+      </script>
+    {% endblock %}
+    {% block scripts %}
+      <script src="{{ 'assets/javascripts/bundle.5a2dcb6a.min.js' | url }}"></script>
+      {% for path in config.extra_javascript %}
+        <script src="{{ path | url }}"></script>
+      {% endfor %}
+    {% endblock %}
+    {% if page.meta and page.meta.ᴴₒᴴₒᴴₒ %}
+      <link rel="stylesheet" href="{{ 'assets/stylesheets/extra.0d2c79a8.min.css' | url }}">
+      <script src="{{ 'assets/javascripts/extra/bundle.5f09fbc3.min.js' | url }}" defer></script>
+    {% endif %}
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+<style>
+    .floating-container {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        padding: 1em;
+        padding-top: 0.5em;
+        padding-bottom: 0.5em;
+        z-index: 9999;
+        background: #673ab6;
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        box-shadow: 0 0 0.2rem #0000001a, 0 0.2rem 0.4rem #0003;
+    }
+
+    .floating-container a {
+        display: inline-block;
+        margin: 5px;
+    }
+
+    .floating-container img {
+        width: 30px;
+    }
+
+    .floating_icon{
+        font-size: 28px;
+        color: white;
+    }
+</style>
+
+<div class="floating-container">
+    <a href="https://github.com/knucklesuganda/py_assimilator" target="_blank">
+        <i class="floating_icon fab fa-github"></i>
+    </a>
+    <a href="https://discord.gg/WErywR7ert" target="_blank">
+        <i class="floating_icon fab fa-discord"></i>
+    </a>
+    <a href="https://t.me/iv_andrew" target="_blank">
+        <i class="floating_icon fab fa-telegram" aria-hidden="true"></i>
+    </a>
+</div>
+
+  </body>
+</html>

--- a/docs/next_update.md
+++ b/docs/next_update.md
@@ -1,0 +1,16 @@
+## PyAssimilator Usability Update(1.2.5)
+
+We are focusing on the usability of the library, allowing you to create and manage patterns more comfortably.
+
+##### Problem
+You can easily use the patterns, but, it can be hard to setup all of them if you have never worked with PyAssimilator before. For example, if you want to use pattern substitution(change the database without changing your code), then it can be hard to manage all the models for different databases. Example of this can be seen here: https://github.com/knucklesuganda/py_assimilator/blob/master/examples/simple_database/models.py
+
+-------------------------------------------------
+
+##### Solution
+We are going to have a registry that is going to contain all patterns with different providers(SQLAlchemy, Redis, etc.). You are going to access that registry with special functions like this:
+repository = create_repository(provider='alchemy', model=User, connection=session())
+crud = create_crud(provider='mongo', model=Product, connection=MongoClient())
+
+
+Most of the patterns are going to be created like this. We will also have a model registry for the same purpose, but the implementation is not known yet. 

--- a/docs/next_update.md
+++ b/docs/next_update.md
@@ -1,16 +1,15 @@
-## PyAssimilator Usability Update(1.2.5)
+## PyAssimilator Model Singularity Update(1.4.0)
 
-We are focusing on the usability of the library, allowing you to create and manage patterns more comfortably.
+We are focusing on the usability of the library, allowing you to use the same model with different data sources.
 
 ##### Problem
-You can easily use the patterns, but, it can be hard to setup all of them if you have never worked with PyAssimilator before. For example, if you want to use pattern substitution(change the database without changing your code), then it can be hard to manage all the models for different databases. Example of this can be seen here: https://github.com/knucklesuganda/py_assimilator/blob/master/examples/simple_database/models.py
+You can easily use the same logic with different data sources. Example of that is: use the same code with SQLAlchemy and MongoDB.
+But, the problem is that you have to create two models: SQLAlchemy model and MongoDB model in your configurations.
+You can see that we create lots of classes in here: https://github.com/knucklesuganda/py_assimilator/blob/master/examples/simple_database/models.py
+The logic and structure of these models is the same, but we kind of copy our code.
 
 -------------------------------------------------
 
 ##### Solution
-We are going to have a registry that is going to contain all patterns with different providers(SQLAlchemy, Redis, etc.). You are going to access that registry with special functions like this:
-repository = create_repository(provider='alchemy', model=User, connection=session())
-crud = create_crud(provider='mongo', model=Product, connection=MongoClient())
-
-
-Most of the patterns are going to be created like this. We will also have a model registry for the same purpose, but the implementation is not known yet. 
+We will create a single class/function that will allow us to use the same model class with different providers and libraries.
+The implementation is not known yet.

--- a/docs/tutorial/how_to_create.md
+++ b/docs/tutorial/how_to_create.md
@@ -1,0 +1,134 @@
+
+
+Right now you know how to interact with database using patterns from [Basic Tutorials](/tutorial/database/). But,
+some information in these tutorials is not completely correct. One of the latest updates called Usability Update allowed
+us to create patterns instantly without using functions described in tutorials.
+
+> It is still important to know how to create patterns using your own functions, and some applications may prefer to use 
+> that instead of new functions.
+
+-----------------------------------------------
+
+## Pattern registry
+
+Pattern registry is a dictionary that contains all the providers and respective patterns. Provider is an external library,
+data source or basically a set of patterns that you are using. Example of providers are: SQLAlchemy, Redis, MongoDB, Cassandra, etc.
+
+Each provider corresponds to a `PatternList` which is basically a class that has our patterns.
+In order to use the functions that create our patterns, we must register our provider first.
+
+----------------------------------------------------
+
+#### Registering the patterns
+
+```python
+from assimilator.core.usability.registry import register_provider, PatternList
+from assimilator.internal.database import InternalRepository, InternalUnitOfWork
+from assimilator.core.services import CRUDService
+
+# Our pattern list:
+internal_patterns = PatternList(
+    repository=InternalRepository,
+    uow=InternalUnitOfWork,
+    crud=CRUDService,
+)
+
+# Register the patterns with provider's name:
+register_provider(provider='internal', pattern_list=internal_patterns)
+```
+
+Fortunately, you don't have to do that most of the time. All providers inside PyAssimilator are already registered,
+and other libraries which interact with PyAssimilator must register them as well. But, that is an option for you if you
+want to change the registry.
+
+
+The function that you will probably use a lot is `find_provider`:
+
+```python
+from assimilator.core.usability.registry import find_provider
+
+# Finds and imports the module if it is not in the registry yet.
+find_provider(provider_path='assimilator.alchemy')
+```
+
+> `find_provider()` is a function that just imports the module. If you are developing a library you still have to use
+> `register_provider()`.
+
+----------------------------------------------------
+
+#### Interacting with the registry
+
+You can find a provider using `get_pattern_list()`:
+
+```python
+from assimilator.core.usability.registry import get_pattern_list
+
+alchemy_patterns = get_pattern_list('alchemy')
+```
+
+You can also unregister patterns using `unregister_provider()`:
+
+```python
+from assimilator.core.usability.registry import unregister_provider
+
+unregister_provider('alchemy')
+# Now, you will not be able to find SQLAlchemy patterns
+
+```
+
+You can also get a pattern class by its name using `get_pattern()`:
+
+```python
+from assimilator.core.usability.registry import get_pattern
+
+alchemy_uow_cls = get_pattern(provider='alchemy', pattern_name='uow')
+```
+
+> However, this is a usability update, meaning that you won't have to use most of these functions. They are low-level,
+> and are only useful when developing an extension library for PyAssimilator or for very specific tasks. 
+
+## Creating the patterns
+
+Let's finally create our patterns using Usability Update:
+
+```python
+from assimilator.core.usability.pattern_creator import create_uow, create_repository, create_crud
+
+# Create repository:
+repository = create_repository(provider='alchemy', model=User, session=alchemy_session())
+
+# Create unit of work:
+uow = create_uow(
+    provider='mongo',
+    model=Product,
+    session=pymongo.client_session.ClientSession(),
+    kwargs_repository={
+        "database": "my_db"
+    }
+)
+
+# Create crud service:
+crud = create_crud(provider='internal', model=CustomModel, session={})
+```
+
+So, instead of writing three separate functions with all the configurations, we can just use a create_PATTERN NAME function
+and easily add a new pattern to our code!
+
+-------------------------------------------------
+#### Custom creation arguments
+
+Some patterns have custom arguments in init function, and you can also provide them like this:
+
+```python
+uow = create_uow(
+    provider='mongo',
+    model=Product,
+    session=pymongo.client_session.ClientSession(),
+    kwargs_repository={     # Custom kwargs for repository
+        "database": "my_db",
+    },
+    kwargs_uow={
+        "custom_argument": True,
+    }
+)
+```

--- a/examples/simple_database/dependencies.py
+++ b/examples/simple_database/dependencies.py
@@ -12,40 +12,46 @@ alchemy_session_creator = sessionmaker(bind=engine)
 internal_session = {}
 
 
-database_registry = {   # That is just one way of doing it, you can try whatever!
+# Database registry contains all the possible patterns and their settings.
+# We do that just as an example, you can try or do whatever you want!
+database_registry = {
     'alchemy': {
-        'model': AlchemyUser,
-        'session_creator': lambda: alchemy_session_creator(),
-        'init_kwargs': {},
+        'model': AlchemyUser,   # Model to be used
+        'session_creator': lambda: alchemy_session_creator(),   # function that can create sessions
+        'kwargs_repository': {},    # Additional settings for the repository
     },
     'internal': {
         'model': InternalUser,
         'session_creator': lambda: internal_session,
-        'init_kwargs': {},
+        'kwargs_repository': {},
     },
     'redis': {
         'model': RedisUser,
         'session_creator': lambda: redis.Redis(),
-        'init_kwargs': {},
+        'kwargs_repository': {},
     },
     'mongo': {
         'model': MongoUser,
         'session_creator': lambda: pymongo.MongoClient(),
-        'init_kwargs': {
+        'kwargs_repository': {
             'database': 'assimilator_users',
         },
     }
 }
 
-database_provider = sys.argv[1] if len(sys.argv) > 1 else "alchemy"
-User = database_registry[database_provider]['model']
+database_provider = sys.argv[1] if len(sys.argv) > 1 else "alchemy"     # get the provider from args
+User = database_registry[database_provider]['model']    # get the model
 
 
 def get_uow():
     dependencies = database_registry[database_provider]
+    model = dependencies['model']
+    session = dependencies['session_creator']()     # create a new connection to the database
+    kwargs_repository = dependencies['kwargs_repository']
+
     return create_uow(
         provider=database_provider,
-        model=dependencies['model'],
-        session=dependencies['session_creator'](),
-        **dependencies['init_kwargs'],
+        model=model,
+        session=session,
+        kwargs_repository=kwargs_repository,
     )

--- a/examples/simple_database/main.py
+++ b/examples/simple_database/main.py
@@ -3,15 +3,15 @@ import operator
 import os
 os.environ['PY_ASSIMILATOR_MESSAGE'] = 'False'
 
-from assimilator.alchemy.database import AlchemyRepository
+from assimilator.core.database import filter_
 from assimilator.core.patterns import LazyCommand
 from assimilator.redis_.database import RedisRepository
 from assimilator.core.database import UnitOfWork, Repository
-from assimilator.internal.database import InternalRepository
-from assimilator.internal.database.specifications.filtering_options import find_attribute
 from assimilator.mongo.database import MongoRepository
-from assimilator.core.database import filter_
 from assimilator.core.database import NotFoundError
+from assimilator.internal.database import InternalRepository
+from assimilator.alchemy.database import AlchemyRepository
+from assimilator.internal.database.specifications.filtering_options import find_attribute
 
 from dependencies import get_uow, User
 

--- a/examples/simplest_example.py
+++ b/examples/simplest_example.py
@@ -8,10 +8,10 @@ You will see how your code becomes easier step-by-step by using CRUDService patt
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy import create_engine, Column, Integer, String, Float
 from assimilator.core.usability.pattern_creator import create_crud
-from assimilator.core.usability.registry import find_patterns
+from assimilator.core.usability.registry import find_provider
 
 
-find_patterns('assimilator.alchemy')    # Import SQLAlchemy patterns
+find_provider('assimilator.alchemy')    # Import SQLAlchemy patterns
 
 # Firstly, we need to create our User model. That code is just normal SQLAlchemy:
 engine = create_engine(url="sqlite:///:memory:")

--- a/examples/simplest_example.py
+++ b/examples/simplest_example.py
@@ -1,0 +1,77 @@
+"""
+That is the example for the people who are just starting with programming.
+Some concepts like Dependency Injection are not followed here.
+
+You will see how your code becomes easier step-by-step by using CRUDService pattern.
+"""
+
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import create_engine, Column, Integer, String, Float
+from assimilator.core.usability.pattern_creator import create_crud
+from assimilator.core.usability.registry import find_patterns
+
+
+find_patterns('assimilator.alchemy')    # Import SQLAlchemy patterns
+
+# Firstly, we need to create our User model. That code is just normal SQLAlchemy:
+engine = create_engine(url="sqlite:///:memory:")
+Base = declarative_base()
+
+
+class AlchemyUser(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer(), primary_key=True)
+    username = Column(String())
+    email = Column(String())
+    balance = Column(Float())
+
+    def __str__(self):
+        return f"{self.id} {self.username} {self.email}"
+
+
+Base.metadata.create_all(engine)
+session_creator = sessionmaker(bind=engine)
+
+# Now, we use PyAssimilator to create CRUDService pattern. It allows us to do Create/Read/Update/Delete operations
+crud = create_crud(
+    provider='alchemy',         # Provider is the external library that we are using. In our case - SQLAlchemy
+    model=AlchemyUser,          # Model is the main entity that we will be working with.
+    session=session_creator(),  # Session is the connection to the data source. In our case - SQLite
+)
+
+
+def create_user():
+    # Now, let's create a function that will allow us to add a user
+    new_user = crud.create({    # Create a user
+        "username": "Andrey",
+        "email": "python.on.papyrus@gmail.com",
+        "balance": 1000000,
+    })
+
+    # The user is created! Let's print our username:
+    print("Hello,", new_user.username)
+
+
+def get_user():
+    # Now, let's get a user using his username:
+    user = crud.get(username="Andrey")  # We use crud.get() to retrieve a single user
+    print(user.username, "has a balance of", user.balance)
+
+
+"""
+So, what did we do?
+
+We created a CRUDService pattern that allows us to add a user to the database with:
+    - No dependencies
+    - Transaction management
+    - Less code
+    - Reproducibility
+
+I hope you liked it and will use PyAssimilator in your projects!
+"""
+
+
+if __name__ == '__main__':
+    create_user()
+    get_user()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Assimilator - the best Python patterns
 site_description: Assimilator Python framework, Domain-Driven Design, DDD, high performance, easy to learn, fast to code
 theme:
   name: material
+  custom_dir: docs/docs_theme
   logo: images/logo.png
   favicon: images/icon.png
   features:
@@ -51,6 +52,7 @@ nav:
   - Video Tutorials: video_tutorials.md
   - Help us make the future🤩: help_framework.md
   - ✨New in 1.2.0✨: new_changes.md
+  - 🕢Next update🕢: next_update.md
 
 repo_url: https://github.com/knucklesuganda/py_assimilator
 repo_name: knucklesuganda/py_assimilator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - Important things: tutorial/important.md
     - Database tutorial: tutorial/database.md
     - Advanced database tutorial: tutorial/advanced_database.md
+    - How to create patterns: tutorial/how_to_create.md
     - Architecture tutorial: tutorial/architecture_tutorial.md
     # - Events tutorial: tutorial/events.md
   - SQLAlchemy:
@@ -51,7 +52,7 @@ nav:
   - Unidentified Patterns: unidentified_patterns.md
   - Video Tutorials: video_tutorials.md
   - Help us make the future🤩: help_framework.md
-  - ✨New in 1.2.0✨: new_changes.md
+  - ✨Usability Update(1.3.0)✨: new_changes.md
   - 🕢Next update🕢: next_update.md
 
 repo_url: https://github.com/knucklesuganda/py_assimilator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = [
 
 [project]
 name = "py_assimilator"
-version = "1.2.3"
+version = "1.3.1"
 authors = [
   { name="Andrey Ivanov", email="python.on.papyrus@gmail.com" },
 ]


### PR DESCRIPTION
## The problem

We had a problem with pattern creation. You had to write three or more functions just to create a pattern, and we assume
that this was too much for an average user. So, that is why we changed the way you create your patterns in the
Usability update!

> You can read the full documentation on Pattern creation here: [How to create patterns](/tutorial/how_to_create/)

Here is an example on how we **used to** create CRUDService pattern:

```python

def get_repository():
    return MongoRepository(
        session=mongo_client,
        model=User,
        database='assimilator_complex'
    )


def get_uow():
    return MongoUnitOfWork(repository=get_repository())


def get_crud():
    return CRUDService(uow=get_uow())


crud = get_crud()

```


----------------------------------------------

## Our solution

Now, instead of writing three functions just to create a pattern, you can just call a function and pass all the parameters
inside it. For example, here is how we create a CRUDService:

```python

crud = create_crud(
    provider='alchemy',         # External library that we are using.
    model=User,                 # Model your CRUDService is going to work with.
    session=session_creator(),  # Database session.
)

```


## In-depth look

There are other functions that allow us to fully inject all the patterns into our new update. Firstly, we have
a pattern registry. Pattern registry is a dictionary that contains all the possible patterns with their provider names.
When we want to create a pattern, we use that pattern registry to find the class that we want to use.

You don't want to interact with pattern registry directly(it is a dictionary, and they do not have any structure in Python).
That is why we have the following functions:

- `register_provider()` - Allows you to register a new provider of your own. 
If you are developing a library that interacts with PyAssimilator, it is a good practice to register your provider.
This way, anyone can easily import your patterns with our new functions.
- `find_provider()` - Allows you to provide a module that should find and register your provider.
- `get_pattern_list()` - Returns a list of all patterns for a provider.
- `unregister_provider()` - Deletes a provider from the registry.
- `get_pattern()` - Low-level function that returns a pattern class.

To find out more about these functions, go to [How to create patterns](/tutorial/how_to_create/)
